### PR TITLE
add compatibility with ipython 0.11

### DIFF
--- a/pylons/commands.py
+++ b/pylons/commands.py
@@ -560,10 +560,16 @@ class ShellCommand(Command):
                 raise ImportError()
 
             # try to use IPython if possible
-            from IPython.Shell import IPShellEmbed
+            try:
+                # ipython >= 0.11
+                from IPython.frontend.terminal.embed import InteractiveShellEmbed
+                shell = InteractiveShellEmbed(banner2=banner)
+            except ImportError:
+                # ipython < 0.11
+                from IPython.Shell import IPShellEmbed
+                shell = IPShellEmbed(argv=self.args)
+                shell.set_banner(shell.IP.BANNER + '\n\n' + banner)
 
-            shell = IPShellEmbed(argv=self.args)
-            shell.set_banner(shell.IP.BANNER + '\n\n' + banner)
             try:
                 shell(local_ns=locs, global_ns={})
             finally:


### PR DESCRIPTION
try to use 0.11 and 0.10 api to open embedded ipython shell
