### PR TITLE
Encode Location HTTP header in redirect responses in UTF-8

### DIFF
--- a/pylons/controllers/util.py
+++ b/pylons/controllers/util.py
@@ -221,4 +221,4 @@ def redirect(url, code=302):
     """
     log.debug("Generating %s redirect" % code)
     exc = status_map[code]
-    raise exc(location=url).exception
+    raise exc(location=url.encode('utf-8')).exception


### PR DESCRIPTION
According to RFC 3987 [0], URIs with special characters should be encoded
in UTF-8.

This commit forces the Location HTTP header in redirect responses to be
encoded in UTF-8. This is in particular important, as current WebOb (version
1.2.3 as of today), which is a permitted dependency of current Pylons, would
encode the location header in latin-1 instead, and fail in resolving that same
URL on the next request.

See liqd/adhocracy#169 for a more in-depth explanation of the problem.

[0] http://tools.ietf.org/html/rfc3987