### PR TITLE
Access WebOb exceptions directly (WebOb 1.4 compatibility)

### DIFF
--- a/pylons/controllers/util.py
+++ b/pylons/controllers/util.py
@@ -174,7 +174,7 @@ def etag_cache(key=None):
         response.headers.pop('Content-Type', None)
         response.headers.pop('Cache-Control', None)
         response.headers.pop('Pragma', None)
-        raise status_map[304]().exception
+        raise status_map[304]()
     else:
         log.debug("ETag didn't match, returning response object")
 
@@ -207,7 +207,7 @@ def abort(status_code=None, detail="", headers=None, comment=None):
                                   comment=comment)
     log.debug("Aborting request, status: %s, detail: %r, headers: %r, "
               "comment: %r", status_code, detail, headers, comment)
-    raise exc.exception
+    raise exc
 
 
 def redirect(url, code=302):
@@ -221,4 +221,4 @@ def redirect(url, code=302):
     """
     log.debug("Generating %s redirect" % code)
     exc = status_map[code]
-    raise exc(location=url).exception
+    raise exc(location=url)

--- a/tests/test_units/test_controller.py
+++ b/tests/test_units/test_controller.py
@@ -36,11 +36,11 @@ class BasicWSGIController(WSGIController):
     def use_redirect(self):
         pylons.response.set_cookie('message', 'Hello World')
         exc = status_map[301]
-        raise exc('/elsewhere').exception
+        raise exc('/elsewhere')
     
     def use_customnotfound(self):
         exc = status_map[404]
-        raise exc('Custom not found').exception
+        raise exc('Custom not found')
     
     def header_check(self):
         pylons.response.headers['Content-Type'] = 'text/plain'


### PR DESCRIPTION
Pylons depends on WebOb 1.1.1+ at this point, so this should be ok. This makes it compatible with WebOb 1.4+, when the deprecated `exception` property on `HTTPException` was finally removed.