### PR TITLE
fix deprecated IPython.frontend usage

### DIFF
--- a/pylons/commands.py
+++ b/pylons/commands.py
@@ -561,8 +561,12 @@ class ShellCommand(Command):
 
             # try to use IPython if possible
             try:
-                # ipython >= 0.11
-                from IPython.frontend.terminal.embed import InteractiveShellEmbed
+                try:
+                    # 1.0 <= ipython
+                    from IPython.terminal.embed import InteractiveShellEmbed
+                except ImportError:
+                    # 0.11 <= ipython < 1.0
+                    from IPython.frontend.terminal.embed import InteractiveShellEmbed
                 shell = InteractiveShellEmbed(banner2=banner)
             except ImportError:
                 # ipython < 0.11


### PR DESCRIPTION
As of version 1.0, using `IPython.frontend` prints a scary message to stderr. This change fixes that and handles the newest interface for starting an interactive shell correctly.